### PR TITLE
Fix styles/scripts with newlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -67,13 +67,13 @@ var bleach = {
 
     if ((mode == 'white' && list.indexOf('script') == -1)
      || (mode == 'black' && list.indexOf('script') != -1)) {
-      html = html.replace(/<script(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/script>/gi, '');
+      html = html.replace(/<script(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/script>/gim, '');
     }
 
 
     if ((mode == 'white' && list.indexOf('style') == -1)
      || (mode == 'black' && list.indexOf('style') != -1)) {
-      html = html.replace(/<style(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/style>/gi, '');
+      html = html.replace(/<style(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/style>/gim, '');
     }
 
     matches.forEach(function(tag){

--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -67,13 +67,13 @@ var bleach = {
 
     if ((mode == 'white' && list.indexOf('script') == -1)
      || (mode == 'black' && list.indexOf('script') != -1)) {
-      html = html.replace(/<script(.*?)>(.*?\r\n)*?(.*?)(.*?\r\n)*?<\/script>/gi, '');
+      html = html.replace(/<script(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/script>/gi, '');
     }
 
 
     if ((mode == 'white' && list.indexOf('style') == -1)
      || (mode == 'black' && list.indexOf('style') != -1)) {
-      html = html.replace(/<style(.*?)>(.*?\r\n)*?(.*?)(.*?\r\n)*?<\/style>/gi, '');
+      html = html.replace(/<style(.*?)>(.*?[\r\n])*?(.*?)(.*?[\r\n])*?<\/style>/gi, '');
     }
 
     matches.forEach(function(tag){

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
     "node": "*"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    vows: "0.5.x"
+  }
 }

--- a/test/script.js
+++ b/test/script.js
@@ -1,0 +1,25 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    bleach = require('../lib/bleach');
+
+var HTML1 = 'This is <a href="#html">HTML</a> with a <script>\nvar x = 1;</script>SCRIPT',
+    HTML2 = 'This is <a href="#html">HTML</a> with a SCRIPT',
+    HTML3 = 'This is HTML with a SCRIPT';
+
+vows.describe('script tests').addBatch({
+
+  'whitelist mode': {
+    topic: function (){ return HTML1; },
+
+    'eliminates script tags but keeps listed tags': function (HTML1){
+      var HTML = bleach.sanitize(HTML1, {mode: 'white', list:['a']});
+      assert.equal(HTML, HTML2);
+    },
+
+    'eliminates all tags when given an empty list': function (HTML1){
+      var HTML = bleach.sanitize(HTML1, {mode: 'white', list:[]});
+      assert.equal(HTML, HTML3);
+    }
+  }
+
+}).export(module);


### PR DESCRIPTION
I was playing with "bleaching" nytimes.com and noticed that some styles and scripts didn't get removed. This seems to have fixed it, and fixes the test case I created. However I don't know if this will cause other unforeseen problems. If you can think of any I can add test cases to figure it out
