### PR TITLE
Entities

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -4,7 +4,8 @@
  * cam@onswipe.com
  */
 
-var fs = require('fs');
+var fs = require('fs'),
+    ent = require('ent');
 
 var bleach = {
 
@@ -89,6 +90,8 @@ var bleach = {
         throw new Error('Unknown sanitization mode "' + mode + '"');
       }
     });
+
+    if ( options.encode_entities ) html = ent.encode( html );
 
     return html;
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ent": "0.0.x"
+  },
   "devDependencies": {
-    vows: "0.5.x"
+    "vows": "0.5.x"
   }
 }

--- a/test/encode.js
+++ b/test/encode.js
@@ -1,0 +1,34 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    bleach = require('../lib/bleach');
+
+var HTML1 = 'This is <a href="#html">HTML</a> with a <script>\nvar x = 1;</script>SCRIPT',
+    HTML2 = 'This is &lt;a href=&quot;#html&quot;&gt;HTML&lt;/a&gt; with a SCRIPT',
+    HTML3 = 'This is HTML with a SCRIPT';
+
+vows.describe('encode tests').addBatch({
+
+  'whitelist mode': {
+    topic: function (){ return HTML1; },
+
+    'eliminates script tags but encodes listed tags': function (HTML1){
+      var HTML = bleach.sanitize(HTML1, {mode: 'white', list:['a'], encode_entities: true});
+      assert.equal(HTML, HTML2);
+    },
+
+    'eliminates all tags when given an empty list': function (HTML1){
+      var HTML = bleach.sanitize(HTML1, {mode: 'white', list:[], encode_entities: true});
+      assert.equal(HTML, HTML3);
+    }
+  },
+
+  'blacklist mode': {
+    topic: function (){ return HTML1; },
+
+    'eliminates listed tags but encodes other tags': function (HTML1){
+      var HTML = bleach.sanitize(HTML1, {mode: 'black', list:['script'], encode_entities: true});
+      assert.equal(HTML, HTML2);
+    }
+  }
+
+}).export(module);


### PR DESCRIPTION
To close Issue #3

Adds a `encode_entities` option that encodes all HTML entities in the resulting string

Adds dependency to [`ent`](https://github.com/substack/node-ent). Also fixed a package.json typo.
