### PR TITLE
Make the filter method have an async option.

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -140,7 +140,7 @@ var bleach = {
 
     html = String(html) || '';
 
-    if (!filters) callback(undefined);
+    if (!filters) callback('no filters provided', undefined);
 
     var available = fs.readdir(__dirname + '/../filters', function() {
       if (Array.isArray(filters)) {
@@ -162,13 +162,13 @@ var bleach = {
         for (var i in available) {
           if (file == available[i]) {
             html = require('../filters/' + file)(html);
-            callback(html);
+            callback(undefined, html);
           }
         }
         } else if (typeof filters == 'function') {
-          html = filters(html);
-          callback(html);
-        } else callback(html);
+          html = filters(undefined, html);
+          callback(undefined, html);
+        } else callback(undefined, html);
     });
   }
 

--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -41,7 +41,7 @@ var bleach = {
         if (attr_val && attr_val.charAt(attr_val.length-1).match(/'|"/)) attr_val = attr_val.slice(0, -1);
         attr = {
           name: attr_name,
-          value: attr_val 
+          value: attr_val
         };
         if (!attr.value) delete attr.value;
         if (attr.name) attrs.push(attr);
@@ -55,7 +55,7 @@ var bleach = {
 
       matches.push(tag);
     }
-    
+
     return matches;
   },
 
@@ -98,7 +98,7 @@ var bleach = {
     return html;
   },
 
-  filter: function(html, filters) {
+  filterSync: function(html, filters) {
     html = String(html) || '';
 
     if (!filters) return;
@@ -131,7 +131,45 @@ var bleach = {
         html = filters(html);
         return html;
       } else return html;
+  },
 
+  filter: function(html, filters, callback) {
+    if (typeof(callback) != 'function') {
+      return bleach.filterSync(html, filters);
+    }
+
+    html = String(html) || '';
+
+    if (!filters) callback(undefined);
+
+    var available = fs.readdir(__dirname + '/../filters', function() {
+      if (Array.isArray(filters)) {
+        for (var i in filters) {
+          if (typeof filters[i] == 'function') {
+            html = filters[i](html);
+          } else {
+            var file = filters[i] + '.js';
+            for (var j in available) {
+              if (file == available[j]) {
+                html = require('../filters/' + file)(html);
+              }
+            }
+          }
+        }
+        return html;
+      } else if (typeof filters == 'string') {
+        var file = filters + '.js';
+        for (var i in available) {
+          if (file == available[i]) {
+            html = require('../filters/' + file)(html);
+            callback(html);
+          }
+        }
+        } else if (typeof filters == 'function') {
+          html = filters(html);
+          callback(html);
+        } else callback(html);
+    });
   }
 
 };


### PR DESCRIPTION
This fixes issue #6
For backwards compatibility, the new filter method falls back on filterSync if no callback is provided.
Existing tests pass, proving the sync fallback works. The async option needs code coverage in the tests.
