### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/bleach.js
+++ b/lib/bleach.js
@@ -5,7 +5,7 @@
  */
 
 var fs = require('fs'),
-    ent = require('ent');
+    he = require('he');
 
 var bleach = {
 
@@ -93,7 +93,7 @@ var bleach = {
       }
     });
 
-    if ( options.encode_entities ) html = ent.encode( html );
+    if ( options.encode_entities ) html = he.encode( html );
 
     return html;
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": "*"
   },
   "dependencies": {
-    "ent": "0.0.x"
+    "he": "0.4.x"
   },
   "devDependencies": {
     "vows": "0.5.x"


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
